### PR TITLE
chore: バージョンを0.0.7にアップデート

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.7] - 2025-11-14
+
+### Fixed
+- CLIバージョン表示が正しく動作しない問題を修正
+  - `michi --version`が`1.0.0`と表示されていた問題を修正
+  - `package.json`から動的にバージョンを読み込むように変更
+  - シンボリックリンク経由での実行時も正しく動作するように条件チェックを改善（`fileURLToPath`と`realpathSync`を使用）
+
 ## [0.0.6] - 2025-11-14
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sk8metal/michi-cli",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Managed Intelligent Comprehensive Hub for Integration - AI-driven development workflow automation",
   "license": "MIT",
   "type": "module",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,6 +5,8 @@
  */
 
 import { Command } from 'commander';
+import { fileURLToPath } from 'url';
+import { realpathSync } from 'fs';
 import { syncTasksToJIRA } from '../scripts/jira-sync.js';
 import { syncToConfluence } from '../scripts/confluence-sync.js';
 import { runPhase } from '../scripts/phase-runner.js';
@@ -16,14 +18,17 @@ import { WorkflowOrchestrator } from '../scripts/workflow-orchestrator.js';
 import { configInteractive } from '../scripts/config-interactive.js';
 import { validateAndReport } from '../scripts/utils/config-validator.js';
 import { config } from 'dotenv';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+
+// package.jsonからバージョンを読み込む
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const packageJsonPath = join(__dirname, '..', 'package.json');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 
 // 環境変数読み込み
 config();
-
-const packageJson = {
-  name: '@michi/cli',
-  version: '1.0.0'
-};
 
 /**
  * 環境変数から承認ゲートのロールリストを取得
@@ -233,8 +238,21 @@ export function createCLI(): Command {
 }
 
 // CLI実行（直接実行時）
-if (import.meta.url === `file://${process.argv[1]}`) {
-  const program = createCLI();
-  program.parse();
+// import.meta.urlとprocess.argv[1]を正規化して比較（シンボリックリンク対応）
+if (process.argv[1]) {
+  try {
+    const currentFile = fileURLToPath(import.meta.url);
+    const executedFile = realpathSync(process.argv[1]);
+    if (currentFile === executedFile) {
+      const program = createCLI();
+      program.parse();
+    }
+  } catch {
+    // realpathSyncが失敗した場合は、直接比較を試みる
+    if (fileURLToPath(import.meta.url) === process.argv[1]) {
+      const program = createCLI();
+      program.parse();
+    }
+  }
 }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,14 +18,17 @@ import { WorkflowOrchestrator } from '../scripts/workflow-orchestrator.js';
 import { configInteractive } from '../scripts/config-interactive.js';
 import { validateAndReport } from '../scripts/utils/config-validator.js';
 import { config } from 'dotenv';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { dirname, join } from 'path';
 
 // package.jsonからバージョンを読み込む
 // コンパイル後は dist/src/cli.js から実行されるため、2階層上がる必要がある
+// テスト環境では src/cli.ts から直接実行されるため、process.cwd()も考慮する
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const packageJsonPath = join(__dirname, '..', '..', 'package.json');
+// まず、コンパイル後のパス（dist/src/cli.js）を試す
+const distPath = join(__dirname, '..', '..', 'package.json');
+const packageJsonPath = existsSync(distPath) ? distPath : join(process.cwd(), 'package.json');
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 
 // 環境変数読み込み

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,9 +22,10 @@ import { readFileSync } from 'fs';
 import { dirname, join } from 'path';
 
 // package.jsonからバージョンを読み込む
+// コンパイル後は dist/src/cli.js から実行されるため、2階層上がる必要がある
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const packageJsonPath = join(__dirname, '..', 'package.json');
+const packageJsonPath = join(__dirname, '..', '..', 'package.json');
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
 
 // 環境変数読み込み


### PR DESCRIPTION
## 変更内容

- package.jsonのバージョンを0.0.6から0.0.7に更新
- CHANGELOG.mdに0.0.7の変更履歴を追加

## 関連する修正

- CLIバージョン表示が正しく動作しない問題を修正（前のコミット）
  - `michi --version`が`1.0.0`と表示されていた問題を修正
  - `package.json`から動的にバージョンを読み込むように変更
  - シンボリックリンク経由での実行時も正しく動作するように条件チェックを改善

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * `--version` が正しいバージョンを表示するようになりました
  * シンボリックリンク経由でのCLI実行時の安定性を向上しました（起動判定を改善）
  * CLIのバージョン表記に関する不具合を修正し、0.0.7リリース用の更新を追加しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->