### PR TITLE
feat: Issue #37 - 環境別テンプレートコピー実装

### DIFF
--- a/scripts/__tests__/setup-existing-project.test.ts
+++ b/scripts/__tests__/setup-existing-project.test.ts
@@ -8,13 +8,35 @@ vi.mock('fs', () => ({
   mkdirSync: vi.fn(),
   cpSync: vi.fn(),
   writeFileSync: vi.fn(),
-  readFileSync: vi.fn(() => '{}')
+  readFileSync: vi.fn(() => '{}'),
+  readdirSync: vi.fn(() => []),
+  statSync: vi.fn()
 }));
 vi.mock('child_process', () => ({
   execSync: vi.fn()
 }));
-vi.mock('./utils/project-finder.js', () => ({
+vi.mock('../utils/project-finder.js', () => ({
   findRepositoryRoot: vi.fn(() => '/test/repo')
+}));
+vi.mock('../constants/environments.js', () => ({
+  getEnvironmentConfig: vi.fn(() => ({
+    rulesDir: '.cursor/rules',
+    commandsDir: '.cursor/commands/kiro',
+    templateSource: 'templates/cursor'
+  })),
+  isSupportedEnvironment: vi.fn(() => true)
+}));
+vi.mock('../constants/languages.js', () => ({
+  isSupportedLanguage: vi.fn(() => true)
+}));
+vi.mock('../template/renderer.js', () => ({
+  createTemplateContext: vi.fn(() => ({
+    LANG_CODE: 'ja',
+    DEV_GUIDELINES: '- Think in English, but generate responses in Japanese',
+    KIRO_DIR: '.kiro',
+    AGENT_DIR: '.cursor'
+  })),
+  renderTemplate: vi.fn((content: string) => content)
 }));
 
 describe('setup-existing-project.ts 修正内容のテスト', () => {
@@ -58,12 +80,14 @@ describe('setup-existing-project.ts 修正内容のテスト', () => {
   it('完了メッセージに scripts/ ディレクトリが含まれていない', () => {
     const projectDir = '/test/repo/projects/test-project';
     const repoRoot = '/test/repo';
+    const envConfigRulesDir = '.cursor/rules';
+    const envConfigCommandsDir = '.cursor/commands/kiro';
     
-    // 実際に作成されるファイルのリスト
+    // 実際に作成されるファイルのリスト（環境別）
     const createdFiles = [
       `${projectDir}/.kiro/project.json`,
-      `${projectDir}/.cursor/rules/ (3ファイル)`,
-      `${projectDir}/.cursor/commands/kiro/ (2ファイル)`,
+      `${projectDir}/${envConfigRulesDir}/`,
+      `${projectDir}/${envConfigCommandsDir}/`,
       `${projectDir}/.kiro/steering/ (3ファイル)`,
       `${projectDir}/.kiro/settings/templates/ (3ファイル)`,
       `${repoRoot}/package.json (新規の場合)`,
@@ -74,6 +98,50 @@ describe('setup-existing-project.ts 修正内容のテスト', () => {
     // scripts/ ディレクトリが含まれていないことを確認
     const hasScriptsDir = createdFiles.some(file => file.includes('scripts/'));
     expect(hasScriptsDir).toBe(false);
+  });
+
+  it('project.jsonにlanguageフィールドが含まれる', () => {
+    const projectJson = {
+      projectId: 'test-project',
+      projectName: 'Test Project',
+      language: 'ja',
+      jiraProjectKey: 'TEST',
+      confluenceLabels: ['project:test-project'],
+      status: 'active',
+      team: [],
+      stakeholders: ['@企画', '@部長'],
+      repository: 'https://github.com/org/test',
+      description: 'Test Projectの開発'
+    };
+
+    expect(projectJson).toHaveProperty('language');
+    expect(projectJson.language).toBe('ja');
+  });
+
+  it('環境別のディレクトリマッピングが正しい', () => {
+    const envConfig = {
+      rulesDir: '.cursor/rules',
+      commandsDir: '.cursor/commands/kiro',
+      templateSource: 'templates/cursor'
+    };
+
+    expect(envConfig.rulesDir).toBe('.cursor/rules');
+    expect(envConfig.commandsDir).toBe('.cursor/commands/kiro');
+    expect(envConfig.templateSource).toBe('templates/cursor');
+  });
+
+  it('テンプレートコンテキストが正しく作成される', () => {
+    const context = {
+      LANG_CODE: 'ja',
+      DEV_GUIDELINES: '- Think in English, but generate responses in Japanese',
+      KIRO_DIR: '.kiro',
+      AGENT_DIR: '.cursor'
+    };
+
+    expect(context).toHaveProperty('LANG_CODE');
+    expect(context).toHaveProperty('DEV_GUIDELINES');
+    expect(context).toHaveProperty('KIRO_DIR');
+    expect(context).toHaveProperty('AGENT_DIR');
   });
 });
 

--- a/scripts/constants/__tests__/environments.test.ts
+++ b/scripts/constants/__tests__/environments.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import {
+  ENV_CONFIG,
+  getEnvironmentConfig,
+  isSupportedEnvironment,
+  getSupportedEnvironments,
+  type Environment,
+  type EnvironmentConfig
+} from '../environments.js';
+
+describe('environments', () => {
+  describe('ENV_CONFIG', () => {
+    it('should have entries for all environments', () => {
+      expect(ENV_CONFIG.claude).toBeDefined();
+      expect(ENV_CONFIG['claude-agent']).toBeDefined();
+      expect(ENV_CONFIG.cursor).toBeDefined();
+    });
+
+    it('should have correct structure for claude', () => {
+      const config = ENV_CONFIG.claude;
+      expect(config.rulesDir).toBe('.claude/rules');
+      expect(config.commandsDir).toBe('.claude/commands/kiro');
+      expect(config.templateSource).toBe('templates/claude');
+    });
+
+    it('should have correct structure for claude-agent', () => {
+      const config = ENV_CONFIG['claude-agent'];
+      expect(config.rulesDir).toBe('.claude/rules');
+      expect(config.commandsDir).toBe('.claude/commands/kiro');
+      expect(config.templateSource).toBe('templates/claude-agent');
+    });
+
+    it('should have correct structure for cursor', () => {
+      const config = ENV_CONFIG.cursor;
+      expect(config.rulesDir).toBe('.cursor/rules');
+      expect(config.commandsDir).toBe('.cursor/commands/kiro');
+      expect(config.templateSource).toBe('templates/cursor');
+    });
+
+    it('should have all required properties for each environment', () => {
+      for (const env of Object.keys(ENV_CONFIG) as Environment[]) {
+        const config = ENV_CONFIG[env];
+        expect(config).toHaveProperty('rulesDir');
+        expect(config).toHaveProperty('commandsDir');
+        expect(config).toHaveProperty('templateSource');
+        expect(typeof config.rulesDir).toBe('string');
+        expect(typeof config.commandsDir).toBe('string');
+        expect(typeof config.templateSource).toBe('string');
+      }
+    });
+  });
+
+  describe('getEnvironmentConfig', () => {
+    it('should return config for valid environment', () => {
+      const config = getEnvironmentConfig('claude');
+      expect(config).toBe(ENV_CONFIG.claude);
+    });
+
+    it('should return config for all supported environments', () => {
+      const environments: Environment[] = ['claude', 'claude-agent', 'cursor'];
+      for (const env of environments) {
+        const config = getEnvironmentConfig(env);
+        expect(config).toBeDefined();
+        expect(config).toBe(ENV_CONFIG[env]);
+      }
+    });
+  });
+
+  describe('isSupportedEnvironment', () => {
+    it('should return true for supported environments', () => {
+      expect(isSupportedEnvironment('claude')).toBe(true);
+      expect(isSupportedEnvironment('claude-agent')).toBe(true);
+      expect(isSupportedEnvironment('cursor')).toBe(true);
+    });
+
+    it('should return false for unsupported environments', () => {
+      expect(isSupportedEnvironment('invalid')).toBe(false);
+      expect(isSupportedEnvironment('vscode')).toBe(false);
+      expect(isSupportedEnvironment('')).toBe(false);
+    });
+
+    it('should work as type guard', () => {
+      const env: string = 'cursor';
+      if (isSupportedEnvironment(env)) {
+        // TypeScript should recognize env as Environment here
+        const config: EnvironmentConfig = ENV_CONFIG[env];
+        expect(config).toBeDefined();
+      }
+    });
+  });
+
+  describe('getSupportedEnvironments', () => {
+    it('should return all supported environments', () => {
+      const environments = getSupportedEnvironments();
+      expect(environments).toHaveLength(3);
+      expect(environments).toContain('claude');
+      expect(environments).toContain('claude-agent');
+      expect(environments).toContain('cursor');
+    });
+
+    it('should return array with correct type', () => {
+      const environments = getSupportedEnvironments();
+      expect(Array.isArray(environments)).toBe(true);
+      environments.forEach(env => {
+        expect(isSupportedEnvironment(env)).toBe(true);
+      });
+    });
+  });
+});
+

--- a/scripts/constants/__tests__/languages.test.ts
+++ b/scripts/constants/__tests__/languages.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  supportedLanguages,
+  DEV_GUIDELINES_MAP,
+  getDevGuidelines,
+  isSupportedLanguage,
+  type SupportedLanguage
+} from '../languages.js';
+
+describe('languages', () => {
+  describe('supportedLanguages', () => {
+    it('should contain 12 languages', () => {
+      expect(supportedLanguages).toHaveLength(12);
+    });
+
+    it('should include expected languages', () => {
+      expect(supportedLanguages).toContain('ja');
+      expect(supportedLanguages).toContain('en');
+      expect(supportedLanguages).toContain('zh-TW');
+      expect(supportedLanguages).toContain('zh');
+      expect(supportedLanguages).toContain('es');
+      expect(supportedLanguages).toContain('pt');
+      expect(supportedLanguages).toContain('de');
+      expect(supportedLanguages).toContain('fr');
+      expect(supportedLanguages).toContain('ru');
+      expect(supportedLanguages).toContain('it');
+      expect(supportedLanguages).toContain('ko');
+      expect(supportedLanguages).toContain('ar');
+    });
+  });
+
+  describe('DEV_GUIDELINES_MAP', () => {
+    it('should have entries for all supported languages', () => {
+      for (const lang of supportedLanguages) {
+        expect(DEV_GUIDELINES_MAP[lang]).toBeDefined();
+        expect(DEV_GUIDELINES_MAP[lang]).not.toBe('');
+      }
+    });
+
+    it('should have English guideline', () => {
+      expect(DEV_GUIDELINES_MAP.en).toBe('- Think in English, generate responses in English');
+    });
+
+    it('should have Japanese guideline with bilingual instruction', () => {
+      expect(DEV_GUIDELINES_MAP.ja).toContain('Think in English');
+      expect(DEV_GUIDELINES_MAP.ja).toContain('日本語');
+    });
+
+    it('should contain bilingual instructions', () => {
+      // Most languages should mention "Think in English" in some form
+      const languagesWithEnglishInstruction = ['ja', 'en', 'es', 'pt', 'de', 'fr', 'ru', 'it', 'ko', 'ar'];
+      for (const lang of languagesWithEnglishInstruction) {
+        expect(DEV_GUIDELINES_MAP[lang as SupportedLanguage]).toContain('Think in English');
+      }
+      
+      // Chinese languages have their own format
+      expect(DEV_GUIDELINES_MAP['zh-TW']).toContain('以英文思考');
+      expect(DEV_GUIDELINES_MAP.zh).toContain('以英文思考');
+    });
+  });
+
+  describe('getDevGuidelines', () => {
+    it('should return guidelines for valid language', () => {
+      const guidelines = getDevGuidelines('ja');
+      expect(guidelines).toBe(DEV_GUIDELINES_MAP.ja);
+    });
+
+    it('should return guidelines for all supported languages', () => {
+      for (const lang of supportedLanguages) {
+        const guidelines = getDevGuidelines(lang);
+        expect(guidelines).toBeDefined();
+        expect(guidelines).toBe(DEV_GUIDELINES_MAP[lang]);
+      }
+    });
+  });
+
+  describe('isSupportedLanguage', () => {
+    it('should return true for supported languages', () => {
+      expect(isSupportedLanguage('ja')).toBe(true);
+      expect(isSupportedLanguage('en')).toBe(true);
+      expect(isSupportedLanguage('zh-TW')).toBe(true);
+    });
+
+    it('should return false for unsupported languages', () => {
+      expect(isSupportedLanguage('xx')).toBe(false);
+      expect(isSupportedLanguage('invalid')).toBe(false);
+      expect(isSupportedLanguage('')).toBe(false);
+    });
+
+    it('should work as type guard', () => {
+      const lang: string = 'ja';
+      if (isSupportedLanguage(lang)) {
+        // TypeScript should recognize lang as SupportedLanguage here
+        const guidelines: string = DEV_GUIDELINES_MAP[lang];
+        expect(guidelines).toBeDefined();
+      }
+    });
+  });
+});
+

--- a/scripts/constants/environments.ts
+++ b/scripts/constants/environments.ts
@@ -1,0 +1,61 @@
+/**
+ * Environment configuration mapping for cc-sdd environments
+ * 
+ * Issue #37: 環境別コピー実装
+ */
+
+export interface EnvironmentConfig {
+  rulesDir: string;
+  commandsDir: string;
+  templateSource: string;
+}
+
+export type Environment = 'claude' | 'claude-agent' | 'cursor';
+
+export const ENV_CONFIG: Record<Environment, EnvironmentConfig> = {
+  'claude': {
+    rulesDir: '.claude/rules',
+    commandsDir: '.claude/commands/kiro',
+    templateSource: 'templates/claude'
+  },
+  'claude-agent': {
+    rulesDir: '.claude/rules',
+    commandsDir: '.claude/commands/kiro',
+    templateSource: 'templates/claude-agent'
+  },
+  'cursor': {
+    rulesDir: '.cursor/rules',
+    commandsDir: '.cursor/commands/kiro',
+    templateSource: 'templates/cursor'
+  }
+};
+
+/**
+ * Get environment configuration
+ * 
+ * @param env - Environment name
+ * @returns Environment configuration
+ */
+export const getEnvironmentConfig = (env: Environment): EnvironmentConfig => {
+  return ENV_CONFIG[env];
+};
+
+/**
+ * Validate if an environment is supported
+ * 
+ * @param env - Environment name to validate
+ * @returns True if supported, false otherwise
+ */
+export const isSupportedEnvironment = (env: string): env is Environment => {
+  return env in ENV_CONFIG;
+};
+
+/**
+ * Get all supported environments
+ * 
+ * @returns Array of supported environment names
+ */
+export const getSupportedEnvironments = (): Environment[] => {
+  return Object.keys(ENV_CONFIG) as Environment[];
+};
+

--- a/scripts/constants/languages.ts
+++ b/scripts/constants/languages.ts
@@ -1,0 +1,70 @@
+/**
+ * Supported languages and development guidelines map
+ * 
+ * Issue #37: 環境別コピー実装
+ */
+
+export const supportedLanguages = [
+  'ja', 'en', 'zh-TW', 'zh', 'es', 'pt', 
+  'de', 'fr', 'ru', 'it', 'ko', 'ar'
+] as const;
+
+export type SupportedLanguage = typeof supportedLanguages[number];
+
+export const DEV_GUIDELINES_MAP: Record<SupportedLanguage, string> = {
+  en: '- Think in English, generate responses in English',
+    
+  ja: '- Think in English, but generate responses in Japanese ' +
+        '(思考は英語、回答の生成は日本語で行うように)',
+    
+  'zh-TW': '- 以英文思考,但以繁體中文生成回應' +
+             '(Think in English, generate in Traditional Chinese)',
+    
+  zh: '- 以英文思考,但以简体中文生成回复' +
+        '(Think in English, generate in Simplified Chinese)',
+    
+  es: '- Think in English, generate responses in Spanish ' +
+        '(Piensa en inglés, genera respuestas en español)',
+    
+  pt: '- Think in English, generate responses in Portuguese ' +
+        '(Pense em inglês, gere respostas em português)',
+    
+  de: '- Think in English, generate responses in German ' +
+        '(Denke auf Englisch, formuliere Antworten auf Deutsch)',
+    
+  fr: '- Think in English, generate responses in French ' +
+        '(Pensez en anglais, générez des réponses en français)',
+    
+  ru: '- Think in English, generate responses in Russian ' +
+        '(Думай по-английски, отвечай по-русски)',
+    
+  it: '- Think in English, generate responses in Italian ' +
+        '(Pensa in inglese, genera risposte in italiano)',
+    
+  ko: '- Think in English, generate responses in Korean ' +
+        '(영어로 사고하고, 한국어로 응답을 생성하세요)',
+    
+  ar: '- Think in English, generate responses in Arabic ' +
+        '(فكر بالإنجليزية وأجب بالعربية)',
+};
+
+/**
+ * Get development guidelines for a specific language
+ * 
+ * @param lang - Language code
+ * @returns Development guidelines string
+ */
+export const getDevGuidelines = (lang: SupportedLanguage): string => {
+  return DEV_GUIDELINES_MAP[lang];
+};
+
+/**
+ * Validate if a language code is supported
+ * 
+ * @param lang - Language code to validate
+ * @returns True if supported, false otherwise
+ */
+export const isSupportedLanguage = (lang: string): lang is SupportedLanguage => {
+  return (supportedLanguages as readonly string[]).includes(lang);
+};
+

--- a/scripts/setup-existing-project.ts
+++ b/scripts/setup-existing-project.ts
@@ -12,18 +12,36 @@
  *   --lang ja
  */
 
-import { cpSync, existsSync, mkdirSync, writeFileSync, readFileSync } from 'fs';
-import { resolve, join, basename } from 'path';
+import { cpSync, existsSync, mkdirSync, writeFileSync, readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, join, basename, dirname } from 'path';
+import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import { findRepositoryRoot } from './utils/project-finder.js';
+import { 
+  type Environment, 
+  getEnvironmentConfig, 
+  isSupportedEnvironment 
+} from './constants/environments.js';
+import { 
+  type SupportedLanguage, 
+  isSupportedLanguage 
+} from './constants/languages.js';
+import { 
+  createTemplateContext, 
+  renderTemplate 
+} from './template/renderer.js';
+
+// ES module で __dirname を取得
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 interface SetupConfig {
   michiPath: string;      // Michiリポジトリのパス
   projectName: string;    // プロジェクト表示名
   jiraKey: string;        // JIRAプロジェクトキー
   labels?: string[];      // Confluenceラベル（オプション）
-  environment?: string;   // cc-sdd環境: 'claude' | 'claude-agent' | 'cursor'
-  langCode?: string;      // 言語コード: 'ja'
+  environment: Environment;   // cc-sdd環境: 'claude' | 'claude-agent' | 'cursor'
+  langCode: SupportedLanguage;      // 言語コード: 'ja'
 }
 
 function parseArgs(): SetupConfig {
@@ -45,10 +63,10 @@ function parseArgs(): SetupConfig {
       config.jiraKey = value;
       break;
     case 'environment':
-      config.environment = value;
+      config.environment = value as Environment;
       break;
     case 'lang':
-      config.langCode = value;
+      config.langCode = value as SupportedLanguage;
       break;
     }
   }
@@ -71,7 +89,52 @@ function parseArgs(): SetupConfig {
     process.exit(1);
   }
   
+  // 環境バリデーション
+  if (!isSupportedEnvironment(config.environment)) {
+    console.error(`Unsupported environment: ${config.environment}`);
+    console.error('Supported environments: claude, claude-agent, cursor');
+    process.exit(1);
+  }
+  
+  // 言語バリデーション
+  if (!isSupportedLanguage(config.langCode)) {
+    console.error(`Unsupported language: ${config.langCode}`);
+    console.error('Supported languages: ja, en, zh-TW, zh, es, pt, de, fr, ru, it, ko, ar');
+    process.exit(1);
+  }
+  
   return config as SetupConfig;
+}
+
+/**
+ * Copy and render templates recursively
+ * 
+ * @param sourceDir - Source directory containing templates
+ * @param destDir - Destination directory for rendered files
+ * @param context - Template context for rendering
+ */
+function copyAndRenderTemplates(
+  sourceDir: string,
+  destDir: string,
+  context: ReturnType<typeof createTemplateContext>
+): void {
+  const entries = readdirSync(sourceDir, { withFileTypes: true });
+  
+  for (const entry of entries) {
+    const sourcePath = join(sourceDir, entry.name);
+    const destPath = join(destDir, entry.name);
+    
+    if (entry.isDirectory()) {
+      // ディレクトリは再帰的にコピー
+      mkdirSync(destPath, { recursive: true });
+      copyAndRenderTemplates(sourcePath, destPath, context);
+    } else if (entry.isFile()) {
+      // ファイルはレンダリングしてコピー
+      const content = readFileSync(sourcePath, 'utf-8');
+      const rendered = renderTemplate(content, context);
+      writeFileSync(destPath, rendered, 'utf-8');
+    }
+  }
 }
 
 async function setupExistingProject(config: SetupConfig): Promise<void> {
@@ -169,6 +232,7 @@ async function setupExistingProject(config: SetupConfig): Promise<void> {
     const projectJson = {
       projectId,
       projectName: config.projectName,
+      language: config.langCode,
       jiraProjectKey: config.jiraKey,
       confluenceLabels: labels,
       status: 'active',
@@ -181,49 +245,46 @@ async function setupExistingProject(config: SetupConfig): Promise<void> {
     writeFileSync('.kiro/project.json', JSON.stringify(projectJson, null, 2));
     console.log('   ✅ project.json created');
   
-    // Step 4: Michiから共通ルールをコピー
-    console.log('\n📋 Step 4: Copying common rules from Michi...');
+    // Step 4: 環境別テンプレートのコピーとレンダリング
+    console.log('\n📋 Step 4: Copying and rendering templates from Michi...');
   
-    // ディレクトリを事前に作成
-    mkdirSync(join(projectDir, '.cursor/rules'), { recursive: true });
-    mkdirSync(join(projectDir, '.cursor/commands/kiro'), { recursive: true });
+    const envConfig = getEnvironmentConfig(config.environment);
+    const templateContext = createTemplateContext(
+      config.langCode,
+      '.kiro',
+      envConfig.rulesDir.startsWith('.') ? envConfig.rulesDir.substring(1, envConfig.rulesDir.indexOf('/', 1)) : envConfig.rulesDir.split('/')[0]
+    );
   
-    const rulesToCopy = [
-      'multi-project.mdc',
-      'github-ssot.mdc',
-      'atlassian-mcp.mdc'
-    ];
+    // テンプレートソースディレクトリ
+    const templateSourceDir = join(config.michiPath, envConfig.templateSource);
   
-    for (const rule of rulesToCopy) {
-      const src = join(config.michiPath, '.cursor/rules', rule);
-      const dest = join(projectDir, '.cursor/rules', rule);
-      if (existsSync(src)) {
-        cpSync(src, dest);
-        console.log(`   ✅ ${rule}`);
-      } else {
-        console.log(`   ⚠️  ${rule} not found in Michi`);
+    if (!existsSync(templateSourceDir)) {
+      console.log(`   ⚠️  Template source not found: ${templateSourceDir}`);
+      console.log('   Skipping template copy');
+    } else {
+      // rulesディレクトリのコピーとレンダリング
+      const rulesTemplateDir = join(templateSourceDir, 'rules');
+      const rulesDestDir = join(projectDir, envConfig.rulesDir);
+      
+      if (existsSync(rulesTemplateDir)) {
+        mkdirSync(rulesDestDir, { recursive: true });
+        copyAndRenderTemplates(rulesTemplateDir, rulesDestDir, templateContext);
+        console.log(`   ✅ Rules copied and rendered to ${envConfig.rulesDir}`);
+      }
+  
+      // commandsディレクトリのコピーとレンダリング
+      const commandsTemplateDir = join(templateSourceDir, 'commands');
+      const commandsDestDir = join(projectDir, envConfig.commandsDir);
+      
+      if (existsSync(commandsTemplateDir)) {
+        mkdirSync(commandsDestDir, { recursive: true });
+        copyAndRenderTemplates(commandsTemplateDir, commandsDestDir, templateContext);
+        console.log(`   ✅ Commands copied and rendered to ${envConfig.commandsDir}`);
       }
     }
   
-    // Step 5: カスタムコマンドをコピー
-    console.log('\n🔧 Step 5: Copying custom commands...');
-  
-    const commandsToCopy = [
-      'confluence-sync.md',
-      'project-switch.md'
-    ];
-  
-    for (const cmd of commandsToCopy) {
-      const src = join(config.michiPath, '.cursor/commands/kiro', cmd);
-      const dest = join(projectDir, '.cursor/commands/kiro', cmd);
-      if (existsSync(src)) {
-        cpSync(src, dest);
-        console.log(`   ✅ ${cmd}`);
-      }
-    }
-  
-    // Step 6: Steeringテンプレートをコピー
-    console.log('\n📚 Step 6: Copying steering templates...');
+    // Step 5: Steeringテンプレートをコピー
+    console.log('\n📚 Step 5: Copying steering templates...');
   
     const steeringDir = join(config.michiPath, '.kiro/steering');
     if (existsSync(steeringDir)) {
@@ -231,8 +292,8 @@ async function setupExistingProject(config: SetupConfig): Promise<void> {
       console.log('   ✅ product.md, tech.md, structure.md');
     }
   
-    // Step 7: テンプレートをコピー
-    console.log('\n📄 Step 7: Copying spec templates...');
+    // Step 6: テンプレートをコピー
+    console.log('\n📄 Step 6: Copying spec templates...');
   
     const templatesDir = join(config.michiPath, '.kiro/settings/templates');
     if (existsSync(templatesDir)) {
@@ -240,8 +301,8 @@ async function setupExistingProject(config: SetupConfig): Promise<void> {
       console.log('   ✅ requirements.md, design.md, tasks.md');
     }
   
-    // Step 8: CLIツールのセットアップ案内
-    console.log('\n⚙️  Step 8: Setting up Michi CLI...');
+    // Step 7: CLIツールのセットアップ案内
+    console.log('\n⚙️  Step 7: Setting up Michi CLI...');
     console.log('   ✅ Michi CLI setup complete!');
     console.log('');
     console.log('   📋 使用方法:');
@@ -253,8 +314,8 @@ async function setupExistingProject(config: SetupConfig): Promise<void> {
     console.log('      npm install -g @sk8metal/michi-cli');
     console.log('      michi jira:sync <feature>');
   
-    // Step 9: package.json と tsconfig.json をリポジトリルートにコピー
-    console.log('\n📦 Step 9: Setting up package.json and TypeScript...');
+    // Step 8: package.json と tsconfig.json をリポジトリルートにコピー
+    console.log('\n📦 Step 8: Setting up package.json and TypeScript...');
   
     // 既存の package.json があるかチェック（リポジトリルート）
     const hasPackageJson = existsSync(join(repoRoot, 'package.json'));
@@ -297,8 +358,8 @@ async function setupExistingProject(config: SetupConfig): Promise<void> {
       console.log('   ℹ️  Existing tsconfig.json found (kept)');
     }
   
-    // Step 10: .env テンプレート作成（プロジェクトディレクトリに）
-    console.log('\n🔐 Step 10: Creating .env template...');
+    // Step 9: .env テンプレート作成（プロジェクトディレクトリに）
+    console.log('\n🔐 Step 9: Creating .env template...');
   
     const envTemplate = `# Atlassian設定（MCP + REST API共通）
 ATLASSIAN_URL=https://your-domain.atlassian.net
@@ -326,8 +387,8 @@ JIRA_PROJECT_KEYS=${config.jiraKey}
       console.log('   ℹ️  .env already exists (kept)');
     }
   
-    // Step 11: README.md を更新（オプション、プロジェクトディレクトリに）
-    console.log('\n📖 Step 11: Updating documentation...');
+    // Step 10: README.md を更新（オプション、プロジェクトディレクトリに）
+    console.log('\n📖 Step 10: Updating documentation...');
   
     const readmePath = join(projectDir, 'README.md');
     if (existsSync(readmePath)) {
@@ -369,8 +430,8 @@ npm run github:create-pr <branch>   # PR作成
       }
     }
   
-    // Step 12: .gitignore 更新（リポジトリルートに）
-    console.log('\n🚫 Step 12: Updating .gitignore...');
+    // Step 11: .gitignore 更新（リポジトリルートに）
+    console.log('\n🚫 Step 11: Updating .gitignore...');
   
     const gitignoreEntries = [
       '# AI Development Workflow',
@@ -418,8 +479,8 @@ npm run github:create-pr <branch>   # PR作成
     console.log('');
     console.log('作成されたファイル:');
     console.log(`  - ${projectDir}/.kiro/project.json`);
-    console.log(`  - ${projectDir}/.cursor/rules/ (3ファイル)`);
-    console.log(`  - ${projectDir}/.cursor/commands/kiro/ (2ファイル)`);
+    console.log(`  - ${projectDir}/${envConfig.rulesDir}/`);
+    console.log(`  - ${projectDir}/${envConfig.commandsDir}/`);
     console.log(`  - ${projectDir}/.kiro/steering/ (3ファイル)`);
     console.log(`  - ${projectDir}/.kiro/settings/templates/ (3ファイル)`);
     console.log(`  - ${repoRoot}/package.json (新規の場合)`);

--- a/scripts/template/__tests__/renderer.test.ts
+++ b/scripts/template/__tests__/renderer.test.ts
@@ -139,6 +139,43 @@ Line 3: .cursor`);
       
       expect(() => renderJsonTemplate(template, context)).toThrow();
     });
+
+    it('should throw with descriptive error for invalid JSON', () => {
+      const template = '{"incomplete": {{LANG_CODE}}';
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      
+      try {
+        renderJsonTemplate(template, context);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        const errorMessage = (error as Error).message;
+        
+        // Should contain descriptive information
+        expect(errorMessage).toContain('Failed to parse rendered JSON template');
+        expect(errorMessage).toContain('Original error:');
+        expect(errorMessage).toContain('Rendered output');
+        expect(errorMessage).toContain('Template context');
+        expect(errorMessage).toContain('LANG_CODE=ja');
+        expect(errorMessage).toContain('KIRO_DIR=.kiro');
+      }
+    });
+
+    it('should preserve original error stack', () => {
+      const template = '{invalid json}';
+      const context = createTemplateContext('en', '.kiro', '.cursor');
+      
+      try {
+        renderJsonTemplate(template, context);
+        expect.fail('Should have thrown an error');
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        const errorStack = (error as Error).stack;
+        
+        // Should contain original error stack
+        expect(errorStack).toContain('Original error stack:');
+      }
+    });
   });
 
   describe('renderTemplates', () => {

--- a/scripts/template/__tests__/renderer.test.ts
+++ b/scripts/template/__tests__/renderer.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createTemplateContext,
+  renderTemplate,
+  renderJsonTemplate,
+  renderTemplates,
+  type TemplateContext
+} from '../renderer.js';
+
+describe('renderer', () => {
+  describe('createTemplateContext', () => {
+    it('should create context with all required fields', () => {
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      
+      expect(context).toHaveProperty('LANG_CODE');
+      expect(context).toHaveProperty('DEV_GUIDELINES');
+      expect(context).toHaveProperty('KIRO_DIR');
+      expect(context).toHaveProperty('AGENT_DIR');
+      expect(context.LANG_CODE).toBe('ja');
+      expect(context.KIRO_DIR).toBe('.kiro');
+      expect(context.AGENT_DIR).toBe('.cursor');
+    });
+
+    it('should include language-specific guidelines', () => {
+      const contextJa = createTemplateContext('ja', '.kiro', '.cursor');
+      expect(contextJa.DEV_GUIDELINES).toContain('日本語');
+      
+      const contextEn = createTemplateContext('en', '.kiro', '.cursor');
+      expect(contextEn.DEV_GUIDELINES).toContain('English');
+    });
+  });
+
+  describe('renderTemplate', () => {
+    it('should replace single placeholder', () => {
+      const template = 'Language: {{LANG_CODE}}';
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      const result = renderTemplate(template, context);
+      
+      expect(result).toBe('Language: ja');
+    });
+
+    it('should replace multiple placeholders', () => {
+      const template = 'Lang: {{LANG_CODE}}, Kiro: {{KIRO_DIR}}, Agent: {{AGENT_DIR}}';
+      const context = createTemplateContext('en', '.kiro', '.claude');
+      const result = renderTemplate(template, context);
+      
+      expect(result).toBe('Lang: en, Kiro: .kiro, Agent: .claude');
+    });
+
+    it('should replace same placeholder multiple times', () => {
+      const template = '{{LANG_CODE}} is {{LANG_CODE}}';
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      const result = renderTemplate(template, context);
+      
+      expect(result).toBe('ja is ja');
+    });
+
+    it('should leave unknown placeholders unchanged', () => {
+      const template = 'Known: {{LANG_CODE}}, Unknown: {{UNKNOWN}}';
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      const result = renderTemplate(template, context);
+      
+      expect(result).toBe('Known: ja, Unknown: {{UNKNOWN}}');
+    });
+
+    it('should handle DEV_GUIDELINES placeholder', () => {
+      const template = '{{DEV_GUIDELINES}}';
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      const result = renderTemplate(template, context);
+      
+      expect(result).toContain('Think in English');
+      expect(result).toContain('日本語');
+    });
+
+    it('should handle empty template', () => {
+      const template = '';
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      const result = renderTemplate(template, context);
+      
+      expect(result).toBe('');
+    });
+
+    it('should handle template with no placeholders', () => {
+      const template = 'No placeholders here';
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      const result = renderTemplate(template, context);
+      
+      expect(result).toBe('No placeholders here');
+    });
+
+    it('should handle multiline template', () => {
+      const template = `Line 1: {{LANG_CODE}}
+Line 2: {{KIRO_DIR}}
+Line 3: {{AGENT_DIR}}`;
+      const context = createTemplateContext('en', '.kiro', '.cursor');
+      const result = renderTemplate(template, context);
+      
+      expect(result).toBe(`Line 1: en
+Line 2: .kiro
+Line 3: .cursor`);
+    });
+  });
+
+  describe('renderJsonTemplate', () => {
+    it('should render and parse JSON template', () => {
+      const template = '{"lang": "{{LANG_CODE}}", "dir": "{{KIRO_DIR}}"}';
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      const result = renderJsonTemplate(template, context);
+      
+      expect(result).toEqual({ lang: 'ja', dir: '.kiro' });
+    });
+
+    it('should handle nested JSON', () => {
+      const template = '{"config": {"lang": "{{LANG_CODE}}", "paths": {"kiro": "{{KIRO_DIR}}"}}}';
+      const context = createTemplateContext('en', '.kiro', '.claude');
+      const result = renderJsonTemplate(template, context);
+      
+      expect(result).toEqual({
+        config: {
+          lang: 'en',
+          paths: {
+            kiro: '.kiro'
+          }
+        }
+      });
+    });
+
+    it('should handle JSON arrays', () => {
+      const template = '["{{LANG_CODE}}", "{{KIRO_DIR}}", "{{AGENT_DIR}}"]';
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      const result = renderJsonTemplate(template, context);
+      
+      expect(result).toEqual(['ja', '.kiro', '.cursor']);
+    });
+
+    it('should throw on invalid JSON', () => {
+      const template = 'invalid json {{LANG_CODE}}';
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      
+      expect(() => renderJsonTemplate(template, context)).toThrow();
+    });
+  });
+
+  describe('renderTemplates', () => {
+    it('should render multiple templates', () => {
+      const templates = {
+        template1: 'Lang: {{LANG_CODE}}',
+        template2: 'Dir: {{KIRO_DIR}}',
+        template3: 'Agent: {{AGENT_DIR}}'
+      };
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      const results = renderTemplates(templates, context);
+      
+      expect(results).toEqual({
+        template1: 'Lang: ja',
+        template2: 'Dir: .kiro',
+        template3: 'Agent: .cursor'
+      });
+    });
+
+    it('should handle empty templates object', () => {
+      const templates = {};
+      const context = createTemplateContext('ja', '.kiro', '.cursor');
+      const results = renderTemplates(templates, context);
+      
+      expect(results).toEqual({});
+    });
+  });
+});
+

--- a/scripts/template/renderer.ts
+++ b/scripts/template/renderer.ts
@@ -1,0 +1,109 @@
+/**
+ * Template renderer with placeholder replacement
+ * 
+ * Issue #37: 環境別コピー実装
+ */
+
+import { SupportedLanguage, getDevGuidelines } from '../constants/languages.js';
+
+export interface TemplateContext {
+  LANG_CODE: SupportedLanguage;
+  DEV_GUIDELINES: string;
+  KIRO_DIR: string;
+  AGENT_DIR: string;
+  PROJECT_ID?: string;
+  FEATURE_NAME?: string;
+  TIMESTAMP?: string;
+}
+
+/**
+ * Create template context for rendering
+ * 
+ * @param lang - Language code
+ * @param kiroDir - .kiro directory name
+ * @param agentDir - Agent directory name (e.g., .cursor, .claude)
+ * @returns Template context object
+ */
+export const createTemplateContext = (
+  lang: SupportedLanguage,
+  kiroDir: string,
+  agentDir: string
+): TemplateContext => ({
+  LANG_CODE: lang,
+  DEV_GUIDELINES: getDevGuidelines(lang),
+  KIRO_DIR: kiroDir,
+  AGENT_DIR: agentDir,
+});
+
+/**
+ * Render template with placeholder replacement
+ * 
+ * Replaces {{KEY}} patterns with values from context
+ * 
+ * @param template - Template string with {{PLACEHOLDER}} patterns
+ * @param context - Template context with replacement values
+ * @returns Rendered template string
+ * 
+ * @example
+ * ```typescript
+ * const template = "Hello {{NAME}}, welcome to {{PLACE}}!";
+ * const context = { NAME: "Alice", PLACE: "Wonderland" };
+ * const result = renderTemplate(template, context);
+ * // Result: "Hello Alice, welcome to Wonderland!"
+ * ```
+ */
+export const renderTemplate = (
+  template: string,
+  context: TemplateContext
+): string => {
+  return template.replace(/\{\{([A-Z_]+)\}\}/g, (match, key) => {
+    const value = context[key as keyof TemplateContext];
+    return value !== undefined ? String(value) : match;
+  });
+};
+
+/**
+ * Render JSON template with placeholder replacement
+ * 
+ * Parses the template as JSON after placeholder replacement
+ * 
+ * @param template - JSON template string with {{PLACEHOLDER}} patterns
+ * @param context - Template context with replacement values
+ * @returns Parsed JSON object
+ * 
+ * @example
+ * ```typescript
+ * const template = '{"lang": "{{LANG_CODE}}", "dir": "{{KIRO_DIR}}"}';
+ * const context = { LANG_CODE: "ja", KIRO_DIR: ".kiro" };
+ * const result = renderJsonTemplate(template, context);
+ * // Result: { lang: "ja", dir: ".kiro" }
+ * ```
+ */
+export const renderJsonTemplate = <T = any>(
+  template: string,
+  context: TemplateContext
+): T => {
+  const rendered = renderTemplate(template, context);
+  return JSON.parse(rendered);
+};
+
+/**
+ * Batch render multiple templates
+ * 
+ * @param templates - Map of template names to template strings
+ * @param context - Template context with replacement values
+ * @returns Map of template names to rendered strings
+ */
+export const renderTemplates = (
+  templates: Record<string, string>,
+  context: TemplateContext
+): Record<string, string> => {
+  const rendered: Record<string, string> = {};
+  
+  for (const [name, template] of Object.entries(templates)) {
+    rendered[name] = renderTemplate(template, context);
+  }
+  
+  return rendered;
+};
+

--- a/scripts/template/renderer.ts
+++ b/scripts/template/renderer.ts
@@ -70,6 +70,7 @@ export const renderTemplate = (
  * @param template - JSON template string with {{PLACEHOLDER}} patterns
  * @param context - Template context with replacement values
  * @returns Parsed JSON object
+ * @throws {Error} If the rendered template is not valid JSON
  * 
  * @example
  * ```typescript
@@ -84,7 +85,30 @@ export const renderJsonTemplate = <T = any>(
   context: TemplateContext
 ): T => {
   const rendered = renderTemplate(template, context);
-  return JSON.parse(rendered);
+  
+  try {
+    return JSON.parse(rendered);
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorStack = error instanceof Error ? error.stack : undefined;
+    
+    // Create descriptive error with context for debugging
+    const debugInfo = [
+      'Failed to parse rendered JSON template',
+      `Original error: ${errorMessage}`,
+      `Rendered output (first 500 chars): ${rendered.substring(0, 500)}${rendered.length > 500 ? '...' : ''}`,
+      `Template context: LANG_CODE=${context.LANG_CODE}, KIRO_DIR=${context.KIRO_DIR}, AGENT_DIR=${context.AGENT_DIR}`
+    ].join('\n');
+    
+    const detailedError = new Error(debugInfo);
+    
+    // Preserve original error stack for diagnostics
+    if (errorStack) {
+      detailedError.stack = `${detailedError.stack}\n\nOriginal error stack:\n${errorStack}`;
+    }
+    
+    throw detailedError;
+  }
 };
 
 /**

--- a/templates/cursor/commands/michi/confluence-sync.md
+++ b/templates/cursor/commands/michi/confluence-sync.md
@@ -5,6 +5,8 @@ description: GitHub の Markdown を Confluence に同期
 
 # Confluence同期コマンド
 
+{{DEV_GUIDELINES}}
+
 このコマンドは、GitHubで管理されている仕様書（requirements, design, tasks）をConfluenceに同期します。
 
 ## 使い方
@@ -26,8 +28,8 @@ description: GitHub の Markdown を Confluence に同期
 
 ## 実行内容
 
-1. `.kiro/project.json` からプロジェクトメタデータを読み込み
-2. `.kiro/specs/<feature>/<doc_type>.md` を読み込み
+1. `{{KIRO_DIR}}/project.json` からプロジェクトメタデータを読み込み
+2. `{{KIRO_DIR}}/specs/<feature>/<doc_type>.md` を読み込み
 3. Markdown → Confluence Storage Format に変換
 4. GitHub URLを埋め込み
 5. Confluenceページを作成または更新
@@ -58,7 +60,7 @@ npm run confluence:sync <feature_name> [doc_type]
 ## 前提条件
 
 - `.env` ファイルに Atlassian 認証情報が設定されている
-- `.kiro/project.json` が存在する
+- `{{KIRO_DIR}}/project.json` が存在する
 - 同期する Markdown ファイルが存在する
 
 ## トラブルシューティング

--- a/templates/cursor/commands/michi/project-switch.md
+++ b/templates/cursor/commands/michi/project-switch.md
@@ -5,6 +5,8 @@ description: プロジェクトを切り替える
 
 # プロジェクト切り替えコマンド
 
+{{DEV_GUIDELINES}}
+
 複数プロジェクトを管理している場合、プロジェクトを切り替えるコマンドです。
 
 ## 使い方
@@ -26,7 +28,7 @@ description: プロジェクトを切り替える
 
 1. プロジェクトIDに対応するGitHubリポジトリを特定
 2. ローカルにクローン（未クローンの場合）またはチェックアウト
-3. `.kiro/project.json` を読み込んで表示
+3. `{{KIRO_DIR}}/project.json` を読み込んで表示
 4. 対応するConfluenceプロジェクトページのURLを表示
 5. JIRAプロジェクトダッシュボードのURLを表示
 
@@ -57,7 +59,7 @@ jj git clone https://github.com/org/<project_id>
 cd <project_id>
 
 # プロジェクト情報を表示
-cat .kiro/project.json
+cat {{KIRO_DIR}}/project.json
 ```
 
 ## 関連コマンド


### PR DESCRIPTION
## 概要
12言語・3環境対応の環境別テンプレートコピー機能を実装

## 実装内容
- scripts/constants/languages.ts: 12言語のDEV_GUIDELINES_MAP
- scripts/constants/environments.ts: ENV_CONFIG マッピング
- scripts/template/renderer.ts: プレースホルダー置換
- setup-existing-project.ts: 環境別コピー統合
- project.jsonにlanguageフィールド追加

## テスト
- 39テスト実装（100%パス）
- 動作確認済み（英語・日本語、単一・複数プロジェクト）

Closes #37

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 複数環境（Claude / Claude‑Agent / Cursor）向け設定と環境別テンプレート選択を追加
  * 12言語対応と言語別開発ガイドラインを実装
  * テンプレートのコンテキスト生成とレンダリングで動的ファイル生成に対応

* **テスト**
  * 環境・言語・テンプレート周りの包括的なユニットテストを追加
  * テンプレートのJSONレンダリングやプレースホルダ挙動の検証を強化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->