### PR TITLE
docs: Add npm version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 AI駆動開発ワークフロー自動化プラットフォーム
 
+[![npm version](https://badge.fury.io/js/@sk8metal%2Fmichi-cli.svg?icon=si%3Anpm)](https://badge.fury.io/js/@sk8metal%2Fmichi-cli)
 [![CI](https://github.com/sk8metalme/michi/actions/workflows/ci.yml/badge.svg)](https://github.com/sk8metalme/michi/actions/workflows/ci.yml)
 [![Test Setup](https://github.com/sk8metalme/michi/actions/workflows/test-setup.yml/badge.svg)](https://github.com/sk8metalme/michi/actions/workflows/test-setup.yml)
 [![Security](https://github.com/sk8metalme/michi/actions/workflows/security.yml/badge.svg)](https://github.com/sk8metalme/michi/actions/workflows/security.yml)


### PR DESCRIPTION
## 概要

README.mdにnpmバージョンバッジを追加しました。

## 変更内容

- npmバージョンバッジを既存のバッジの最初に追加
- バッジのURL: https://badge.fury.io/js/@sk8metal%2Fmichi-cli

## 表示順序

1. npm version（新規追加）
2. CI
3. Test Setup
4. Security
5. codecov

## 確認事項

- ✅ バッジが正しく表示されることを確認
- ✅ リンクが正しく機能することを確認

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * README.mdにnpmバージョンバッジを追加しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->