### PR TITLE
docs: .kiro/steering/と.kiro/specs/の管理主体を明確化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ docs/
 - **重要**: `.kiro/settings/` はGit管理外（`.gitignore`に含む）
   - 各開発者がローカルで実行して生成
   - cc-sddのバージョンアップで最新のベストプラクティスを取得
-  - プロジェクト固有の設定は `.kiro/steering/` と `.kiro/specs/` で管理
+  - プロジェクト固有の設定は、ユーザーが `.kiro/steering/` と `.kiro/specs/` を作成して管理
 
 ## 参考リンク
 

--- a/docs/user-guide/hands-on/claude-agent-setup.md
+++ b/docs/user-guide/hands-on/claude-agent-setup.md
@@ -248,11 +248,11 @@ tree -L 3 .kiro .claude
 # ├── settings/                 # cc-sddで生成（Git管理外）
 # │   ├── rules/               # Spec-Driven Development用ルール
 # │   └── templates/           # Spec用テンプレート
-# ├── steering/                # Michiで管理（Gitにコミット）
+# ├── steering/                # ユーザーが作成（プロジェクトでGit管理）
 # │   ├── product.md
 # │   ├── structure.md
 # │   └── tech.md
-# └── specs/                   # 各機能の仕様（Gitにコミット）
+# └── specs/                   # ユーザーが作成（プロジェクトでGit管理）
 #
 # .claude/
 # ├── commands/


### PR DESCRIPTION
## 問題

PR #87で導入されたドキュメントに誤解を招く記述がありました：

- `.kiro/steering/` を「**Michiで管理（Gitにコミット）**」と記載
- 実際にはMichiリポジトリに**存在せず**、ユーザーが作成するファイル

## 修正内容

### 1. `docs/user-guide/hands-on/claude-agent-setup.md` (L251, L255)

**変更前:**
```markdown
# ├── steering/                # Michiで管理（Gitにコミット）
# └── specs/                   # 各機能の仕様（Gitにコミット）
```

**変更後:**
```markdown
# ├── steering/                # ユーザーが作成（プロジェクトでGit管理）
# └── specs/                   # ユーザーが作成（プロジェクトでGit管理）
```

### 2. `CLAUDE.md` (L86)

**変更前:**
```markdown
- プロジェクト固有の設定は `.kiro/steering/` と `.kiro/specs/` で管理
```

**変更後:**
```markdown
- プロジェクト固有の設定は、ユーザーが `.kiro/steering/` と `.kiro/specs/` を作成して管理
```

## 背景

調査の結果、以下が判明：

| ディレクトリ | 実態 | Git管理 |
|-------------|------|---------|
| `templates/michi/cc-sdd-overrides/` | **Michiが管理** | ✅ Michiリポジトリ |
| `.kiro/settings/` | cc-sddが生成 | ❌ 各開発者が生成 |
| `.kiro/steering/` | **ユーザーが作成** | ✅ ユーザーのプロジェクト |
| `.kiro/specs/` | **ユーザーが作成** | ✅ ユーザーのプロジェクト |

- `.kiro/steering/` はMichiリポジトリに**存在しない**
- `setup-existing.ts` は存在しないパスからコピーを試み、常にスキップ
- ユーザーがcc-sddテンプレートを参考に手動作成する設計

## 影響範囲

- ドキュメントの明確化のみ
- コード変更なし
- 既存機能への影響なし

## 関連Issue/PR

- 関連PR: #87 (cc-sdd-overrides実装)
- Issue: なし（ドキュメント改善）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント

* ステアリングおよびスペック関連のディレクトリの管理方式について、ドキュメントを更新しました。ユーザーが自身で作成・管理する方式に変更され、システムによる自動管理から移行しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->