### PR TITLE
fix: Address code review feedback for michi init command

### DIFF
--- a/scripts/config-global.ts
+++ b/scripts/config-global.ts
@@ -137,7 +137,7 @@ async function main(): Promise<void> {
     console.log('\n🎉 グローバル設定が完了しました！');
     console.log('   この設定はすべてのプロジェクトに適用されます。');
     console.log('   プロジェクト固有の設定で上書きしたい場合は:');
-    console.log('   npm run config:interactive');
+    console.log('   グローバル設定をコピーして .michi/config.json として編集してください');
   } catch (error) {
     console.error(
       '❌ エラーが発生しました:',

--- a/scripts/utils/interactive-helpers.ts
+++ b/scripts/utils/interactive-helpers.ts
@@ -35,6 +35,10 @@ export async function select(
   defaultValue?: string,
   maxRetries: number = 3,
 ): Promise<string> {
+  if (choices.length === 0) {
+    throw new Error('select: choices must contain at least one option');
+  }
+
   console.log(`\n${prompt}`);
   choices.forEach((choice, index) => {
     const defaultMark = defaultValue === choice.value ? ' (デフォルト)' : '';
@@ -69,10 +73,12 @@ export async function select(
   }
 
   // 最大試行回数に達した場合はデフォルト値または最初の選択肢を返す
+  // 注: choices.length > 0 は関数冒頭で保証されている
+  const fallbackValue = defaultValue || choices[0].value;
   console.log(
-    `⚠️  最大試行回数に達しました。デフォルト値を使用します: ${defaultValue || choices[0].value}`,
+    `⚠️  最大試行回数に達しました。デフォルト値を使用します: ${fallbackValue}`,
   );
-  return defaultValue || choices[0].value;
+  return fallbackValue;
 }
 
 /**


### PR DESCRIPTION
## Summary

PR #96 のコードレビューで指摘された2つの問題を修正しました。

- **scripts/config-global.ts**: 削除された `config:interactive` コマンドへの参照を削除
- **scripts/utils/interactive-helpers.ts**: 空配列のエラーハンドリングを追加

## Changes

### scripts/config-global.ts
- 削除された `npm run config:interactive` への参照を削除
- 新しいワークフロー（グローバル設定のコピー＋編集）を案内するメッセージに変更

### scripts/utils/interactive-helpers.ts
- `select()` 関数に `choices.length === 0` のチェックを追加
- `fallbackValue` 変数を導入してコードの可読性を向上

## Related Issues

この PR は以下のコードレビューの指摘に対応しています：
- PR #96 - scripts/config-global.ts:140 - 存在しないコマンドの参照
- PR #96 - scripts/utils/interactive-helpers.ts:76 - 空配列のエラーハンドリング

## Test Plan

- [x] Lint チェック通過
- [x] 全テスト通過（19/19 テストケース）
- [x] 既存機能への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 設定ガイダンスメッセージを改善しました。グローバル設定ファイルを `.michi/config.json` にコピーして編集する方法をユーザーに指示するようになります。
  * インタラクティブ選択時に、選択肢が空の場合のエラーハンドリングを強化しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->