### PR TITLE
Hotfix v0.8.1: Fix init command template copying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2025-12-19
+
+### Fixed
+
+- **`michi init --claude-agent` でagentsディレクトリが配置されない問題を修正**
+  - `init.ts` のStep 4が `--michi-path` オプション指定時のみ実行されていた問題を解決
+  - テンプレートディレクトリを自動検出し、常にテンプレートをコピーするように変更
+  - claude-agent環境で agents と rules の両方をコピーするロジックを追加（setup-existing.ts と同様）
+  - エラー処理を追加し、テンプレートコピー失敗時も処理を継続
+
 ## [0.8.0] - 2025-12-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sk8metal/michi-cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Managed Intelligent Comprehensive Hub for Integration - AI-driven development workflow automation",
   "license": "MIT",
   "type": "module",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -558,10 +558,10 @@ JIRA_ISSUE_TYPE_SUBTASK=10037
     console.log('   ℹ️  .env already exists (skipped)');
   }
 
-  // Step 4: テンプレート/ルールのコピー（--michi-path 指定時のみ）
-  if (config.michiPath) {
-    console.log('\n📋 Step 4: Copying templates and rules...');
+  // Step 4: テンプレート/ルールのコピー
+  console.log('\n📋 Step 4: Copying templates and rules...');
 
+  try {
     const templatesDir = resolveTemplatesDir(config.michiPath);
     const envConfig = getEnvironmentConfig(config.environment);
     const templateContext = createTemplateContext(
@@ -575,16 +575,46 @@ JIRA_ISSUE_TYPE_SUBTASK=10037
     const templateSourceDir = join(templatesDir, envConfig.templateSource);
 
     if (existsSync(templateSourceDir)) {
-      // rulesディレクトリ
-      const templateDirName =
-        config.environment === 'claude-agent' ? 'agents' : 'rules';
-      const rulesTemplateDir = join(templateSourceDir, templateDirName);
-      const rulesDestDir = join(currentDir, envConfig.rulesDir);
+      // rulesディレクトリ（claude-agent環境では agents と rules の両方をコピー）
+      if (config.environment === 'claude-agent') {
+        // 1. agents ディレクトリをコピー
+        const agentsTemplateDir = join(templateSourceDir, 'agents');
+        const agentsDestDir = join(currentDir, '.claude/agents');
+        if (existsSync(agentsTemplateDir)) {
+          mkdirSync(agentsDestDir, { recursive: true });
+          copyAndRenderTemplates(
+            agentsTemplateDir,
+            agentsDestDir,
+            templateContext,
+          );
+          console.log('   ✅ Agents copied to .claude/agents');
+        }
 
-      if (existsSync(rulesTemplateDir)) {
-        mkdirSync(rulesDestDir, { recursive: true });
-        copyAndRenderTemplates(rulesTemplateDir, rulesDestDir, templateContext);
-        console.log(`   ✅ Rules copied to ${envConfig.rulesDir}`);
+        // 2. rules ディレクトリをコピー
+        const rulesTemplateDir = join(templateSourceDir, 'rules');
+        const rulesDestDir = join(currentDir, '.claude/rules');
+        if (existsSync(rulesTemplateDir)) {
+          mkdirSync(rulesDestDir, { recursive: true });
+          copyAndRenderTemplates(
+            rulesTemplateDir,
+            rulesDestDir,
+            templateContext,
+          );
+          console.log('   ✅ Rules copied to .claude/rules');
+        }
+      } else {
+        // その他の環境では従来通り rules のみコピー
+        const rulesTemplateDir = join(templateSourceDir, 'rules');
+        const rulesDestDir = join(currentDir, envConfig.rulesDir);
+        if (existsSync(rulesTemplateDir)) {
+          mkdirSync(rulesDestDir, { recursive: true });
+          copyAndRenderTemplates(
+            rulesTemplateDir,
+            rulesDestDir,
+            templateContext,
+          );
+          console.log(`   ✅ Rules copied to ${envConfig.rulesDir}`);
+        }
       }
 
       // commandsディレクトリ
@@ -626,10 +656,15 @@ JIRA_ISSUE_TYPE_SUBTASK=10037
         );
         console.log('   ✅ Spec templates copied');
       }
+    } else {
+      console.log(`   ⚠️  Template source not found: ${templateSourceDir}`);
     }
-  } else {
-    console.log('\n⚠️  Step 4: Skipped (--michi-path not specified)');
-    console.log('   テンプレートをコピーするには --michi-path オプションを指定してください');
+  } catch (error) {
+    console.error(
+      '   ⚠️  Template copying failed:',
+      error instanceof Error ? error.message : error,
+    );
+    console.log('   Continuing with project initialization...');
   }
 
   // Step 5: ワークフロー設定


### PR DESCRIPTION
## 問題

`michi init --claude-agent --lang ja` を実行しても、`.claude/agents/` ディレクトリが配置されない問題がありました。

## 原因

`src/commands/init.ts` の Step 4 が以下の2つの問題を抱えていました:

1. **`--michi-path` オプション必須**: `--michi-path` が指定されていない場合、テンプレートコピー処理がスキップされていた
2. **古いロジック**: claude-agent 環境で agents と rules の両方をコピーする処理が実装されていなかった（setup-existing.ts で実装済み）

## 修正内容

### `src/commands/init.ts` の変更

1. **テンプレートディレクトリの自動検出**
   - `resolveTemplatesDir()` を常に呼び出し、npm パッケージ内のテンプレートを自動検出
   - `--michi-path` オプションなしでも動作するように修正

2. **claude-agent 環境での複数ディレクトリコピー**
   - `setup-existing.ts` と同じロジックを実装
   - `.claude/agents/` と `.claude/rules/` の両方をコピー

3. **エラーハンドリング追加**
   - try-catch でエラーをキャッチし、テンプレートコピー失敗時も処理を継続

### package.json / CHANGELOG.md
- バージョンを 0.8.1 に更新
- CHANGELOGに修正内容を追加

## テスト

- ✅ ビルド成功
- ✅ 全テスト成功 (279 tests passed)
- ✅ Lint成功

## 確認方法

```bash
npx @sk8metal/michi-cli@0.8.1 init --claude-agent --lang ja
ls -la .claude/
# agents/ と rules/ の両方が存在することを確認
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 初期化処理でエージェントディレクトリが正しく配置されるよう修正
  * テンプレート複製が常に実行されるよう修正
  * Claude Agent環境でエージェントルールの両方が正しくコピーされるよう修正
  * テンプレート複製失敗時でも初期化処理が継続されるようエラーハンドリングを改善

* **Chores**
  * バージョンを 0.8.1 に更新

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->