### PR TITLE
Release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2025-12-19
+
+### Removed
+
+- **未使用の依存関係を削除**
+  - `googleapis` パッケージを削除（ソースコード内で使用されていないことを確認）
+  - パッケージサイズを削減（712行の依存関係を削除）
+
 ## [0.8.1] - 2025-12-19
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sk8metal/michi-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Managed Intelligent Comprehensive Hub for Integration - AI-driven development workflow automation",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## リリース内容

v0.8.2 をリリースします。

### 変更内容

- googleapis パッケージを削除（ソースコード内で使用されていないことを確認）
- パッケージサイズを削減（712行の依存関係を削除）

### リリース後の手順

PRマージ後、以下のコマンドでリリースタグを作成してください：

```bash
git checkout main
git pull origin main
git tag -a v0.8.2 -m "Release version 0.8.2"
git push origin v0.8.2
```

タグをpushすると、GitHub Actionsで自動的にnpm publishとGitHub Releaseが作成されます。