### PR TITLE
fix: multi-repoコマンドにprojectRootパラメータを追加

### DIFF
--- a/src/commands/multi-repo-ci-status.ts
+++ b/src/commands/multi-repo-ci-status.ts
@@ -253,7 +253,7 @@ export async function multiRepoCIStatus(
   }
 
   // 2. プロジェクト存在確認
-  const project = await findProject(projectName);
+  const project = await findProject(projectName, projectRoot);
   if (!project) {
     throw new Error(`プロジェクト「${projectName}」が見つかりません`);
   }

--- a/src/commands/multi-repo-confluence-sync.ts
+++ b/src/commands/multi-repo-confluence-sync.ts
@@ -89,7 +89,7 @@ export async function multiRepoConfluenceSync(
   const { docType, projectRoot = process.cwd() } = options;
 
   // 1. プロジェクト存在確認
-  const config = getConfig();
+  const config = getConfig(projectRoot);
   const project = config.multiRepoProjects?.find(p => p.name === projectName);
 
   if (!project) {

--- a/src/commands/multi-repo-init.ts
+++ b/src/commands/multi-repo-init.ts
@@ -68,7 +68,7 @@ export async function multiRepoInit(
   }
 
   // 4. 既存プロジェクト重複チェック
-  const existingProject = await findProject(projectName);
+  const existingProject = await findProject(projectName, projectRoot);
   if (existingProject) {
     throw new Error(`プロジェクト「${projectName}」は既に存在します`);
   }

--- a/src/commands/multi-repo-test.ts
+++ b/src/commands/multi-repo-test.ts
@@ -87,7 +87,7 @@ export async function multiRepoTest(
   }
 
   // 2. プロジェクト存在確認
-  const project = await findProject(projectName);
+  const project = await findProject(projectName, projectRoot);
   if (!project) {
     throw new Error(`プロジェクト「${projectName}」が見つかりません`);
   }


### PR DESCRIPTION
## 概要
マルチリポジトリ環境で正しいプロジェクトルートを参照できるように、`findProject()` と `getConfig()` に `projectRoot` パラメータを渡すように修正しました。

## 変更内容
- `src/commands/multi-repo-ci-status.ts`: `findProject()` に `projectRoot` を渡すように修正
- `src/commands/multi-repo-confluence-sync.ts`: `getConfig()` に `projectRoot` を渡すように修正
- `src/commands/multi-repo-init.ts`: `findProject()` に `projectRoot` を渡すように修正
- `src/commands/multi-repo-test.ts`: `findProject()` に `projectRoot` を渡すように修正

## テストプラン
- [x] 既存のテストが成功すること（pre-commitフックで確認済み）
- [ ] マルチリポジトリ環境で各コマンドが正しく動作すること

## 変更統計
4ファイル変更、4行追加、4行削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * マルチリポジトリコマンド全体でプロジェクト検出と設定読み込みの処理を改善しました。プロジェクトルートの相対的な検出により、複数リポジトリ環境でのパス解決がより堅牢になります。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->