### PR TITLE
fix: Phase 0 Result型移行に関連するテスト修正

### DIFF
--- a/scripts/utils/__tests__/multi-repo-validator.test.ts
+++ b/scripts/utils/__tests__/multi-repo-validator.test.ts
@@ -483,7 +483,7 @@ describe('validateLocalPath - Michi導入チェック', () => {
     // .git ディレクトリを作成しない（Gitリポジトリでない）
 
     const result = validateLocalPath(repository);
-    expect(result.success).toBe(false);
+    expect(result.isValid).toBe(false);
     expect(result.hasMichiSetup).toBe(false);
     expect(result.michiSetupCommand).toBeNull();
     expect(result.errors).toContain(

--- a/src/commands/__tests__/multi-repo-add-repo.test.ts
+++ b/src/commands/__tests__/multi-repo-add-repo.test.ts
@@ -70,7 +70,7 @@ describe('multiRepoAddRepo', () => {
         repositories: [],
       });
       vi.spyOn(validator, 'validateRepositoryUrl').mockReturnValue({
-        isValid: true,
+        success: true,
         errors: [],
         warnings: [],
       });
@@ -105,7 +105,7 @@ describe('multiRepoAddRepo', () => {
         ],
       });
       vi.spyOn(validator, 'validateRepositoryUrl').mockReturnValue({
-        isValid: true,
+        success: true,
         errors: [],
         warnings: [],
       });
@@ -124,7 +124,7 @@ describe('multiRepoAddRepo', () => {
         repositories: [],
       });
       vi.spyOn(validator, 'validateRepositoryUrl').mockReturnValue({
-        isValid: true,
+        success: true,
         errors: [],
         warnings: [],
       });
@@ -153,7 +153,7 @@ describe('multiRepoAddRepo', () => {
         repositories: [],
       });
       vi.spyOn(validator, 'validateRepositoryUrl').mockReturnValue({
-        isValid: true,
+        success: true,
         errors: [],
         warnings: [],
       });
@@ -227,7 +227,7 @@ describe('multiRepoAddRepo', () => {
         repositories: [],
       });
       vi.spyOn(validator, 'validateRepositoryUrl').mockReturnValue({
-        isValid: true,
+        success: true,
         errors: [],
         warnings: [],
       });
@@ -252,7 +252,7 @@ describe('multiRepoAddRepo', () => {
         repositories: [],
       });
       vi.spyOn(validator, 'validateRepositoryUrl').mockReturnValue({
-        isValid: true,
+        success: true,
         errors: [],
         warnings: [],
       });


### PR DESCRIPTION
## 概要

PR #143のResult型移行で発生した9件のテスト失敗を修正します。

## 修正内容

### 1. multi-repo-add-repo.test.ts
- **問題**: モックの戻り値が古いインターフェース（`isValid`）を使用
- **修正**: `isValid: true` → `success: true` に変更（6箇所）
- **結果**: ✅ 全11テスト合格

```diff
  vi.spyOn(validator, 'validateRepositoryUrl').mockReturnValue({
-   isValid: true,
+   success: true,
    errors: [],
    warnings: [],
  });
```

### 2. multi-repo-validator.test.ts
- **問題**: 一括置換で誤って `.isValid` → `.success` に変更
- **修正**: `result.success` → `result.isValid` に戻す（1箇所）
- **理由**: `LocalPathValidationResult` は Phase 0 の移行対象外（複雑な拡張型のため）
- **結果**: ✅ 全45テスト合格

```diff
  const result = validateLocalPath(repository);
- expect(result.success).toBe(false);
+ expect(result.isValid).toBe(false);
```

## テスト結果

| 項目 | 修正前 | 修正後 | 変化 |
|------|--------|--------|------|
| 失敗 | 71件 | 62件 | ⬇️ 9件減少 |
| 合格 | 705件 | 714件 | ⬆️ 9件増加 |
| 成功率 | 90.3% | 91.5% | ⬆️ 1.2% |

## 残りの62件について

残りの失敗は `init.test.ts` のテスト干渉問題です：
- **現象**: フルテストスイート実行時のみ失敗、単独実行では全テスト合格
- **影響**: Result型移行とは無関係
- **対応**: #144 で別途対応中

## 検証方法

```bash
# 修正したテストファイルを単独実行
npm test -- src/commands/__tests__/multi-repo-add-repo.test.ts
# → Test Files  1 passed (1)
# → Tests  11 passed (11) ✅

npm test -- scripts/utils/__tests__/multi-repo-validator.test.ts  
# → Test Files  1 passed (1)
# → Tests  45 passed (45) ✅
```

## 関連Issue

- #140: Phase 0: オニオンアーキテクチャ移行準備
- #144: init.test.tsのテスト干渉問題

## 関連PR

- #143: Phase 0 - validator移行をResult型に統一

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 検証ユーティリティのAPI署名を更新し、戻り値のプロパティ名を変更しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->