### PR TITLE
fix: multi-repo-validator.test.tsをResult型に対応

### DIFF
--- a/scripts/__tests__/multi-repo-validator.test.ts
+++ b/scripts/__tests__/multi-repo-validator.test.ts
@@ -19,38 +19,38 @@ describe('validateProjectName', () => {
   describe('正常ケース', () => {
     it('有効な英字プロジェクト名を受け入れる', () => {
       const result = validateProjectName('my-project');
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
     it('有効な日本語プロジェクト名を受け入れる', () => {
       const result = validateProjectName('マルチリポジトリ');
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
     it('英字、数字、ハイフンを含むプロジェクト名を受け入れる', () => {
       const result = validateProjectName('project-123-test');
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
     it('アンダースコアを含むプロジェクト名を受け入れる', () => {
       const result = validateProjectName('my_project_name');
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
     it('100文字のプロジェクト名を受け入れる', () => {
       const name = 'a'.repeat(100);
       const result = validateProjectName(name);
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
     it('1文字のプロジェクト名を受け入れる', () => {
       const result = validateProjectName('a');
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
   });
@@ -58,7 +58,7 @@ describe('validateProjectName', () => {
   describe('パストラバーサル攻撃対策', () => {
     it('../を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('../malicious');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain path traversal characters (/, \\)',
       );
@@ -66,7 +66,7 @@ describe('validateProjectName', () => {
 
     it('./を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('./current');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain path traversal characters (/, \\)',
       );
@@ -74,7 +74,7 @@ describe('validateProjectName', () => {
 
     it('/を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('project/name');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain path traversal characters (/, \\)',
       );
@@ -82,7 +82,7 @@ describe('validateProjectName', () => {
 
     it('\\を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('project\\name');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain path traversal characters (/, \\)',
       );
@@ -90,7 +90,7 @@ describe('validateProjectName', () => {
 
     it('複数のパストラバーサル文字を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('../../etc/passwd');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain path traversal characters (/, \\)',
       );
@@ -100,7 +100,7 @@ describe('validateProjectName', () => {
   describe('相対パス攻撃対策', () => {
     it('.（カレントディレクトリ）を拒否する', () => {
       const result = validateProjectName('.');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not be relative path components (., ..)',
       );
@@ -108,7 +108,7 @@ describe('validateProjectName', () => {
 
     it('..（親ディレクトリ）を拒否する', () => {
       const result = validateProjectName('..');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not be relative path components (., ..)',
       );
@@ -118,7 +118,7 @@ describe('validateProjectName', () => {
   describe('制御文字対策', () => {
     it('ヌル文字(\\x00)を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('project\x00name');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain control characters',
       );
@@ -126,7 +126,7 @@ describe('validateProjectName', () => {
 
     it('改行文字(\\n)を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('project\nname');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain control characters',
       );
@@ -134,7 +134,7 @@ describe('validateProjectName', () => {
 
     it('キャリッジリターン(\\r)を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('project\rname');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain control characters',
       );
@@ -142,7 +142,7 @@ describe('validateProjectName', () => {
 
     it('タブ文字(\\t)を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('project\tname');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain control characters',
       );
@@ -150,7 +150,7 @@ describe('validateProjectName', () => {
 
     it('ターミナルエスケープシーケンス(\\x1B[)を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('project\x1B[31mname');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain control characters',
       );
@@ -158,7 +158,7 @@ describe('validateProjectName', () => {
 
     it('DEL文字(\\x7F)を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('project\x7Fname');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain control characters',
       );
@@ -166,7 +166,7 @@ describe('validateProjectName', () => {
 
     it('複数の制御文字を含むプロジェクト名を拒否する', () => {
       const result = validateProjectName('project\x00\n\r\tname');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must not contain control characters',
       );
@@ -177,7 +177,7 @@ describe('validateProjectName', () => {
     it('101文字のプロジェクト名を拒否する', () => {
       const name = 'a'.repeat(101);
       const result = validateProjectName(name);
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must be between 1 and 100 characters',
       );
@@ -185,7 +185,7 @@ describe('validateProjectName', () => {
 
     it('空文字列のプロジェクト名を拒否する', () => {
       const result = validateProjectName('');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must be between 1 and 100 characters',
       );
@@ -194,7 +194,7 @@ describe('validateProjectName', () => {
     it('200文字のプロジェクト名を拒否する', () => {
       const name = 'a'.repeat(200);
       const result = validateProjectName(name);
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must be between 1 and 100 characters',
       );
@@ -204,7 +204,7 @@ describe('validateProjectName', () => {
   describe('複合エラーケース', () => {
     it('複数のバリデーションエラーを同時に検出する', () => {
       const result = validateProjectName('../project\x00/name');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors.length).toBeGreaterThan(1);
       expect(result.errors).toContain(
         'Project name must not contain path traversal characters (/, \\)',
@@ -217,7 +217,7 @@ describe('validateProjectName', () => {
     it('長すぎるプロジェクト名とパストラバーサル文字を同時に検出する', () => {
       const name = 'a'.repeat(101) + '/';
       const result = validateProjectName(name);
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Project name must be between 1 and 100 characters',
       );
@@ -232,31 +232,31 @@ describe('validateJiraKey', () => {
   describe('正常ケース', () => {
     it('2文字の大文字英字を受け入れる', () => {
       const result = validateJiraKey('AB');
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
     it('10文字の大文字英字を受け入れる', () => {
       const result = validateJiraKey('ABCDEFGHIJ');
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
     it('一般的なJIRAキー形式を受け入れる (PROJ)', () => {
       const result = validateJiraKey('PROJ');
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
     it('一般的なJIRAキー形式を受け入れる (TICKET)', () => {
       const result = validateJiraKey('TICKET');
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
     it('一般的なJIRAキー形式を受け入れる (MYPROJECT)', () => {
       const result = validateJiraKey('MYPROJECT');
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
   });
@@ -264,19 +264,19 @@ describe('validateJiraKey', () => {
   describe('小文字エラー', () => {
     it('小文字のみのJIRAキーを拒否する', () => {
       const result = validateJiraKey('abc');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
 
     it('大文字と小文字が混在するJIRAキーを拒否する', () => {
       const result = validateJiraKey('Proj');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
 
     it('小文字を含むJIRAキーを拒否する', () => {
       const result = validateJiraKey('PROJect');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
   });
@@ -284,25 +284,25 @@ describe('validateJiraKey', () => {
   describe('長さエラー', () => {
     it('1文字のJIRAキーを拒否する（短すぎる）', () => {
       const result = validateJiraKey('A');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
 
     it('11文字のJIRAキーを拒否する（長すぎる）', () => {
       const result = validateJiraKey('ABCDEFGHIJK');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
 
     it('15文字のJIRAキーを拒否する（長すぎる）', () => {
       const result = validateJiraKey('ABCDEFGHIJKLMNO');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
 
     it('空文字列のJIRAキーを拒否する', () => {
       const result = validateJiraKey('');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
   });
@@ -310,25 +310,25 @@ describe('validateJiraKey', () => {
   describe('数字を含むエラー', () => {
     it('数字のみのJIRAキーを拒否する', () => {
       const result = validateJiraKey('123');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
 
     it('数字を含むJIRAキーを拒否する (ABC123)', () => {
       const result = validateJiraKey('ABC123');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
 
     it('数字で始まるJIRAキーを拒否する', () => {
       const result = validateJiraKey('123ABC');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
 
     it('数字が混在するJIRAキーを拒否する', () => {
       const result = validateJiraKey('AB1CD2');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
   });
@@ -336,25 +336,25 @@ describe('validateJiraKey', () => {
   describe('特殊文字エラー', () => {
     it('ハイフンを含むJIRAキーを拒否する', () => {
       const result = validateJiraKey('PROJ-123');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
 
     it('アンダースコアを含むJIRAキーを拒否する', () => {
       const result = validateJiraKey('PROJ_NAME');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
 
     it('スペースを含むJIRAキーを拒否する', () => {
       const result = validateJiraKey('PROJ NAME');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
 
     it('記号を含むJIRAキーを拒否する', () => {
       const result = validateJiraKey('PROJ@NAME');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('JIRA key must be 2-10 uppercase letters');
     });
   });
@@ -366,7 +366,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'https://github.com/owner/repository',
       );
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
@@ -374,7 +374,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'https://github.com/my-org/my-repo',
       );
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
@@ -382,7 +382,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'https://github.com/org123/repo456',
       );
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
 
@@ -390,7 +390,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'https://github.com/my-org/my-project-test',
       );
-      expect(result.isValid).toBe(true);
+      expect(result.success).toBe(true);
       expect(result.errors).toHaveLength(0);
     });
   });
@@ -398,13 +398,13 @@ describe('validateRepositoryUrl', () => {
   describe('空文字列エラー', () => {
     it('空文字列を拒否する', () => {
       const result = validateRepositoryUrl('');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('Repository URL is empty');
     });
 
     it('スペースのみの文字列を拒否する', () => {
       const result = validateRepositoryUrl('   ');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('Repository URL is empty');
     });
   });
@@ -414,7 +414,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'git@github.com:owner/repository.git',
       );
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Repository URL must be in GitHub format: https://github.com/{owner}/{repo}',
       );
@@ -426,7 +426,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'http://github.com/owner/repository',
       );
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('Repository URL must use HTTPS protocol');
     });
   });
@@ -436,7 +436,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'https://gitlab.com/owner/repository',
       );
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Repository URL must be in GitHub format: https://github.com/{owner}/{repo}',
       );
@@ -446,7 +446,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'https://github.com/owner/repository/issues',
       );
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Repository URL must be in GitHub format: https://github.com/{owner}/{repo}',
       );
@@ -454,7 +454,7 @@ describe('validateRepositoryUrl', () => {
 
     it('ownerのみのURLを拒否する', () => {
       const result = validateRepositoryUrl('https://github.com/owner');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Repository URL must be in GitHub format: https://github.com/{owner}/{repo}',
       );
@@ -466,7 +466,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'https://github.com/owner/repository.git',
       );
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Repository URL must not include .git extension',
       );
@@ -478,7 +478,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'https://github.com/your-org/repository',
       );
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Repository URL contains placeholder values',
       );
@@ -488,7 +488,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'https://github.com/owner/your-repo',
       );
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Repository URL contains placeholder values',
       );
@@ -498,7 +498,7 @@ describe('validateRepositoryUrl', () => {
       const result = validateRepositoryUrl(
         'https://github.com/owner/repo-name',
       );
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain(
         'Repository URL contains placeholder values',
       );
@@ -508,7 +508,7 @@ describe('validateRepositoryUrl', () => {
   describe('無効なURL形式', () => {
     it('無効なURL形式を拒否する', () => {
       const result = validateRepositoryUrl('not-a-url');
-      expect(result.isValid).toBe(false);
+      expect(result.success).toBe(false);
       expect(result.errors).toContain('Repository URL format is invalid');
     });
 
@@ -522,7 +522,7 @@ describe('validateRepositoryUrl', () => {
       // URLコンストラクタはスペースを自動エンコードするため、
       // GitHub形式チェックでは通過する可能性があります
       // このテストは実装の動作を反映して調整します
-      expect(result.isValid).toBe(true); // URLエンコードされるため有効
+      expect(result.success).toBe(true); // URLエンコードされるため有効
       expect(result.errors).toHaveLength(0);
     });
   });


### PR DESCRIPTION
## 問題

PR #143/#145でvalidatorがResult型に移行されたが、`multi-repo-validator.test.ts`のテストコードが未更新で62テスト失敗していた。

- **単独実行**: 69/69成功 ✅
- **フルスイート実行**: 62失敗（全体成功率91.5%）❌
- **根本原因**: 古いAPI `result.isValid` を使用

## 修正内容

### Result型移行済みの3つのvalidator
- `validateProjectName()` 
- `validateJiraKey()`
- `validateRepositoryUrl()`

これらのテストで `result.isValid` → `result.success` に置換（62箇所）

### 未移行のvalidator
- `validateLocalPath()` - `LocalPathValidationResult`を返す（7箇所は`result.isValid`のまま）

## 検証結果

✅ **単独実行**: 69/69成功  
✅ **フルスイート実行**: 776/776成功  
✅ **成功率**: 91.5% → **100%** 🎉

## 変更ファイル

- `scripts/__tests__/multi-repo-validator.test.ts` (62箇所置換)

## Result型の構造

```typescript
// OLD (削除済み)
{ isValid: boolean, errors: string[], warnings: string[] }

// NEW (Result<T, E>)
{ success: boolean, value: T | undefined, errors: E[], warnings: E[] }
```

## テストプラン

```bash
# 単独実行
npm test -- --run scripts/__tests__/multi-repo-validator.test.ts

# フルスイート実行
npm test -- --run
```

## 関連PR

- PR #143: Phase 0 - validator移行をResult型に統一
- PR #145: Phase 0 Result型移行に関連するテスト修正（一部のテストのみ）
- PR #146: init.test.tsのテスト干渉問題を修正

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **破壊的変更**
  * 検証結果の構造が更新されました。検証APIの結果でチェック対象プロパティが変更されたため、システムの統合部分の確認が必要です。その他のメタデータフィールドは変わらずご利用いただけます。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->