### PR TITLE
refactor: Task 1.3 - ValidationResult インターフェースの統合

### DIFF
--- a/scripts/utils/config-validator.ts
+++ b/scripts/utils/config-validator.ts
@@ -19,18 +19,6 @@ import type { Result } from './types/validation.js';
 import { success, failure } from './types/validation.js';
 
 /**
- * バリデーション結果（情報メッセージ付き）
- * info フィールドが必要な場合に使用
- * @deprecated 新規コードでは Result<boolean, string> の使用を推奨。infoは warnings に統合してください
- */
-export interface ValidationResult {
-  valid: boolean;
-  errors: string[];
-  warnings: string[];
-  info: string[];
-}
-
-/**
  * Result型を拡張した情報メッセージ付きバリデーション結果
  * config-validator固有の拡張型
  */

--- a/scripts/utils/feature-name-validator.ts
+++ b/scripts/utils/feature-name-validator.ts
@@ -7,15 +7,6 @@ import type { Result } from './types/validation.js';
 import { success, failure } from './types/validation.js';
 
 /**
- * バリデーション結果
- * @deprecated Use Result<boolean, string> from ./types/validation.js
- */
-export interface ValidationResult {
-  valid: boolean;
-  errors: string[];
-}
-
-/**
  * kebab-case形式の正規表現
  * - 小文字の英数字で始まる
  * - 小文字の英数字とハイフンのみ

--- a/scripts/utils/multi-repo-validator.ts
+++ b/scripts/utils/multi-repo-validator.ts
@@ -13,19 +13,15 @@ import type { Result } from './types/validation.js';
 import { success, failure } from './types/validation.js';
 
 /**
- * バリデーション結果
- * @deprecated Use Result<boolean, string> from ./types/validation.js
+ * LocalPathバリデーション結果（詳細情報付き）
+ *
+ * Note: This is a specialized validation result type for local path validation.
+ * It includes additional metadata beyond the standard Result<T, E> pattern.
  */
-export interface ValidationResult {
+export interface LocalPathValidationResult {
   isValid: boolean;
   errors: string[];
   warnings: string[];
-}
-
-/**
- * LocalPathバリデーション結果（詳細情報付き）
- */
-export interface LocalPathValidationResult extends ValidationResult {
   exists: boolean;
   isGitRepository: boolean;
   currentBranch: string | null;

--- a/scripts/utils/security-validator.ts
+++ b/scripts/utils/security-validator.ts
@@ -9,16 +9,6 @@ import type { Result } from './types/validation.js';
 import { success, failure } from './types/validation.js';
 
 /**
- * バリデーション結果
- * @deprecated Use Result<boolean, string> from ./types/validation.js
- */
-export interface ValidationResult {
-  isValid: boolean;
-  errors: string[];
-  warnings: string[];
-}
-
-/**
  * APIトークン形式の検証
  */
 export function validateAtlassianToken(token: string): Result<boolean, string> {

--- a/scripts/validate-phase.ts
+++ b/scripts/validate-phase.ts
@@ -17,9 +17,14 @@ type Phase =
   | 'phase-a'
   | 'phase-b';
 
+/**
+ * Phase validation result type
+ * Based on Result<T, E> pattern but specialized for phase validation
+ */
 interface ValidationResult {
   phase: Phase;
   success: boolean;
+  value: void;
   errors: string[];
   warnings: string[];
 }
@@ -63,7 +68,7 @@ function validateRequirements(feature: string): ValidationResult {
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     errors.push(`❌ spec.json読み込みエラー: ${message}`);
-    return { phase: 'requirements', success: false, errors, warnings };
+    return { phase: 'requirements', success: false, value: undefined, errors, warnings };
   }
   
   // 3. Confluenceページ作成チェック（必須）
@@ -85,6 +90,7 @@ function validateRequirements(feature: string): ValidationResult {
   return {
     phase: 'requirements',
     success: errors.length === 0,
+    value: undefined,
     errors,
     warnings
   };
@@ -116,7 +122,7 @@ function validateDesign(feature: string): ValidationResult {
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     errors.push(`❌ spec.json読み込みエラー: ${message}`);
-    return { phase: 'design', success: false, errors, warnings };
+    return { phase: 'design', success: false, value: undefined, errors, warnings };
   }
   
   // 3. 前提: 要件定義完了チェック
@@ -138,6 +144,7 @@ function validateDesign(feature: string): ValidationResult {
   return {
     phase: 'design',
     success: errors.length === 0,
+    value: undefined,
     errors,
     warnings
   };
@@ -198,7 +205,7 @@ function validateTasks(feature: string): ValidationResult {
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);
     errors.push(`❌ spec.json読み込みエラー: ${message}`);
-    return { phase: 'tasks', success: false, errors, warnings };
+    return { phase: 'tasks', success: false, value: undefined, errors, warnings };
   }
   
   // 3. 前提: 設計完了チェック
@@ -237,6 +244,7 @@ function validateTasks(feature: string): ValidationResult {
   return {
     phase: 'tasks',
     success: errors.length === 0,
+    value: undefined,
     errors,
     warnings
   };
@@ -262,6 +270,7 @@ function validateEnvironmentSetup(feature: string): ValidationResult {
   return {
     phase: 'environment-setup',
     success: errors.length === 0,
+    value: undefined,
     errors,
     warnings
   };
@@ -286,6 +295,7 @@ function validatePhaseA(feature: string): ValidationResult {
   return {
     phase: 'phase-a',
     success: errors.length === 0,
+    value: undefined,
     errors,
     warnings
   };
@@ -310,6 +320,7 @@ function validatePhaseB(feature: string): ValidationResult {
   return {
     phase: 'phase-b',
     success: errors.length === 0,
+    value: undefined,
     errors,
     warnings
   };


### PR DESCRIPTION
## 概要

Task 1.3: 5ファイルの異なるValidationResult定義を共通Result<T, E>型に統一

## 変更内容

### 1. 非推奨インターフェースの削除

以下のファイルから非推奨のValidationResultインターフェースを削除：

- **security-validator.ts**: `ValidationResult { isValid, errors, warnings }` を削除
- **feature-name-validator.ts**: `ValidationResult { valid, errors }` を削除
- **multi-repo-validator.ts**: `ValidationResult { isValid, errors, warnings }` を削除
- **config-validator.ts**: `ValidationResult { valid, errors, warnings, info }` を削除

### 2. 型の統一と標準化

- **multi-repo-validator.ts**: `LocalPathValidationResult` を独立した型として維持（9フィールドの詳細情報を持つ特殊型）
- **config-validator.ts**: `ResultWithInfo` を正式な `Result<T,E>` 拡張として維持（info フィールド必要）
- **validate-phase.ts**: カスタム `ValidationResult` を `Result<T,E>` パターンに準拠させる
  - `value: void` フィールドを追加
  - 9箇所のreturn文を更新

## テスト結果

✅ **全776テスト成功 (100%)**
```
Test Files  72 passed (72)
     Tests  776 passed (776)
```

## コード品質

✅ **TypeScript型チェック**: エラーなし
✅ **ESLint**: 警告なし
✅ **Pre-commit hooks**: 通過

## コード削減効果

- **変更ファイル**: 5ファイル
- **削減行数**: 43行削除、19行追加 = **24行の削減**
- **型安全性**: TypeScript strict mode完全準拠

## 関連Issue

Part of #140 - Phase 0: オニオンアーキテクチャ移行準備（コード削減）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * バリデーション関連の内部型定義を整理し、非推奨なインターフェースを削除しました。これにより、コード構造がシンプルになり、保守性が向上しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->